### PR TITLE
Admin interface enhancements

### DIFF
--- a/authorizenet/admin.py
+++ b/authorizenet/admin.py
@@ -7,6 +7,7 @@ class ResponseAdmin(admin.ModelAdmin):
                     'response_reason_text',
                     'auth_code',
                     'trans_id']
+    readonly_fields = ('created',)
 
 admin.site.register(Response, ResponseAdmin)
 
@@ -14,5 +15,6 @@ admin.site.register(Response, ResponseAdmin)
 class CIMResponseAdmin(admin.ModelAdmin):
     list_display = ['result_code',
                     'result']
+    readonly_fields = ('created',)
 
 admin.site.register(CIMResponse, CIMResponseAdmin)

--- a/authorizenet/migrations/0004_auto__add_field_response_created__add_field_cimresponse_created__chg_f.py
+++ b/authorizenet/migrations/0004_auto__add_field_response_created__add_field_cimresponse_created__chg_f.py
@@ -1,0 +1,92 @@
+# encoding: utf-8
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        
+        # Adding field 'Response.created'
+        db.add_column('authorizenet_response', 'created', self.gf('django.db.models.fields.DateTimeField')(auto_now_add=True, null=True, blank=True), keep_default=False)
+
+        # Adding field 'CIMResponse.created'
+        db.add_column('authorizenet_cimresponse', 'created', self.gf('django.db.models.fields.DateTimeField')(auto_now_add=True, null=True, blank=True), keep_default=False)
+
+        # Changing field 'CIMResponse.result_text'
+        db.alter_column('authorizenet_cimresponse', 'result_text', self.gf('django.db.models.fields.TextField')(max_length=1023))
+
+    def backwards(self, orm):
+        
+        # Deleting field 'Response.created'
+        db.delete_column('authorizenet_response', 'created')
+
+        # Deleting field 'CIMResponse.created'
+        db.delete_column('authorizenet_cimresponse', 'created')
+
+        # Changing field 'CIMResponse.result_text'
+        db.alter_column('authorizenet_cimresponse', 'result_text', self.gf('django.db.models.fields.CharField')(max_length=1023))
+
+    models = {
+        'authorizenet.cimresponse': {
+            'Meta': {'object_name': 'CIMResponse'},
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'result': ('django.db.models.fields.CharField', [], {'max_length': '8'}),
+            'result_code': ('django.db.models.fields.CharField', [], {'max_length': '8'}),
+            'result_text': ('django.db.models.fields.TextField', [], {'max_length': '1023'}),
+            'transaction_response': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['authorizenet.Response']", 'null': 'True', 'blank': 'True'})
+        },
+        'authorizenet.response': {
+            'MD5_Hash': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'Meta': {'object_name': 'Response'},
+            'account_number': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '10', 'blank': 'True'}),
+            'address': ('django.db.models.fields.CharField', [], {'max_length': '60'}),
+            'amount': ('django.db.models.fields.CharField', [], {'max_length': '16'}),
+            'auth_code': ('django.db.models.fields.CharField', [], {'max_length': '10'}),
+            'avs_code': ('django.db.models.fields.CharField', [], {'max_length': '10'}),
+            'card_type': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '10', 'blank': 'True'}),
+            'cavv_response': ('django.db.models.fields.CharField', [], {'max_length': '2', 'blank': 'True'}),
+            'city': ('django.db.models.fields.CharField', [], {'max_length': '40'}),
+            'company': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'country': ('django.db.models.fields.CharField', [], {'max_length': '60'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'null': 'True', 'blank': 'True'}),
+            'cust_id': ('django.db.models.fields.CharField', [], {'max_length': '20'}),
+            'cvv2_resp_code': ('django.db.models.fields.CharField', [], {'max_length': '2', 'blank': 'True'}),
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'duty': ('django.db.models.fields.CharField', [], {'max_length': '16', 'blank': 'True'}),
+            'email': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'fax': ('django.db.models.fields.CharField', [], {'max_length': '25'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'freight': ('django.db.models.fields.CharField', [], {'max_length': '16', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'invoice_num': ('django.db.models.fields.CharField', [], {'max_length': '20', 'blank': 'True'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'method': ('django.db.models.fields.CharField', [], {'max_length': '10'}),
+            'phone': ('django.db.models.fields.CharField', [], {'max_length': '25'}),
+            'po_num': ('django.db.models.fields.CharField', [], {'max_length': '25', 'blank': 'True'}),
+            'response_code': ('django.db.models.fields.CharField', [], {'max_length': '2'}),
+            'response_reason_code': ('django.db.models.fields.CharField', [], {'max_length': '15'}),
+            'response_reason_text': ('django.db.models.fields.TextField', [], {}),
+            'response_subcode': ('django.db.models.fields.CharField', [], {'max_length': '10'}),
+            'ship_to_address': ('django.db.models.fields.CharField', [], {'max_length': '60', 'blank': 'True'}),
+            'ship_to_city': ('django.db.models.fields.CharField', [], {'max_length': '40', 'blank': 'True'}),
+            'ship_to_company': ('django.db.models.fields.CharField', [], {'max_length': '50', 'blank': 'True'}),
+            'ship_to_country': ('django.db.models.fields.CharField', [], {'max_length': '60', 'blank': 'True'}),
+            'ship_to_first_name': ('django.db.models.fields.CharField', [], {'max_length': '50', 'blank': 'True'}),
+            'ship_to_last_name': ('django.db.models.fields.CharField', [], {'max_length': '50', 'blank': 'True'}),
+            'ship_to_state': ('django.db.models.fields.CharField', [], {'max_length': '40', 'blank': 'True'}),
+            'ship_to_zip': ('django.db.models.fields.CharField', [], {'max_length': '20', 'blank': 'True'}),
+            'state': ('django.db.models.fields.CharField', [], {'max_length': '40'}),
+            'tax': ('django.db.models.fields.CharField', [], {'max_length': '16', 'blank': 'True'}),
+            'tax_exempt': ('django.db.models.fields.CharField', [], {'max_length': '16', 'blank': 'True'}),
+            'test_request': ('django.db.models.fields.CharField', [], {'default': "'FALSE'", 'max_length': '10', 'blank': 'True'}),
+            'trans_id': ('django.db.models.fields.CharField', [], {'max_length': '255', 'db_index': 'True'}),
+            'type': ('django.db.models.fields.CharField', [], {'max_length': '20', 'db_index': 'True'}),
+            'zip': ('django.db.models.fields.CharField', [], {'max_length': '20'})
+        }
+    }
+
+    complete_apps = ['authorizenet']

--- a/authorizenet/models.py
+++ b/authorizenet/models.py
@@ -170,6 +170,7 @@ class Response(models.Model):
 
     card_type = models.CharField(max_length=10, default="", blank=True)
     account_number = models.CharField(max_length=10, default="", blank=True)
+    created = models.DateTimeField(auto_now_add=True, null=True)
 
     objects = ResponseManager()
 
@@ -186,8 +187,9 @@ class CIMResponse(models.Model):
     result = models.CharField(max_length=8)
     result_code = models.CharField(max_length=8,
                                    choices=CIM_RESPONSE_CODE_CHOICES)
-    result_text = models.CharField(max_length=1023)
+    result_text = models.TextField()
     transaction_response = models.ForeignKey(Response, blank=True, null=True)
+    created = models.DateTimeField(auto_now_add=True, null=True)
 
     @property
     def success(self):


### PR DESCRIPTION
I added a field to record the creation date for `Response` and `CIMResponse` models and I made the `result_text` field in `CIMResponse` use a textarea in the admin interface because it can get pretty long.  Additionally the size of `result_text` is no longer limited.
