### PR TITLE
Shipping form addition, modify CVV2 field, added check to disable authorize customer emails

### DIFF
--- a/authorizenet/fields.py
+++ b/authorizenet/fields.py
@@ -96,9 +96,9 @@ class CreditCardExpiryField(forms.MultiValueField):
         return None
 
 
-class CreditCardCVV2Field(forms.IntegerField):
+class CreditCardCVV2Field(forms.CharField):
     def __init__(self, *args, **kwargs):
-        kwargs.setdefault('max_value', 9999)
+        kwargs.setdefault('max_length', 4)
         super(CreditCardCVV2Field, self).__init__(*args, **kwargs)
 
 

--- a/authorizenet/fields.py
+++ b/authorizenet/fields.py
@@ -96,9 +96,9 @@ class CreditCardExpiryField(forms.MultiValueField):
         return None
 
 
-class CreditCardCVV2Field(forms.CharField):
+class CreditCardCVV2Field(forms.IntegerField):
     def __init__(self, *args, **kwargs):
-        kwargs.setdefault('max_length', 4)
+        kwargs.setdefault('max_value', 9999)
         super(CreditCardCVV2Field, self).__init__(*args, **kwargs)
 
 

--- a/authorizenet/forms.py
+++ b/authorizenet/forms.py
@@ -69,6 +69,15 @@ class BillingAddressForm(forms.Form):
     country = CountryField(label="Country", initial="US")
     zip = forms.CharField(20, label="Postal / Zip Code")
 
+class ShippingAddressForm(forms.Form):
+    ship_to_first_name = forms.CharField(50, label="First Name")
+    ship_to_last_name = forms.CharField(50, label="Last Name")
+    ship_to_company = forms.CharField(50, label="Company", required=False)
+    ship_to_address = forms.CharField(60, label="Street Address")
+    ship_to_city = forms.CharField(40, label="City")
+    ship_to_state = forms.CharField(label="State")
+    ship_to_zip = forms.CharField(20, label="Postal / Zip Code")
+    ship_to_country = CountryField(label="Country", initial="US")
 
 class AIMPaymentForm(forms.Form):
     card_num = CreditCardField(label="Credit Card Number")

--- a/authorizenet/utils.py
+++ b/authorizenet/utils.py
@@ -50,6 +50,8 @@ def process_payment(form_data, extra_data):
     data['x_exp_date'] = data['x_exp_date'].strftime('%m%y')
     if getattr(settings, 'AUTHNET_FORCE_TEST_REQUEST', False):
         data['x_test_request'] = 'TRUE'
+    if hasattr(settings, 'AUTHNET_EMAIL_CUSTOMER'):
+        data['x_email_customer'] = settings.AUTHNET_EMAIL_CUSTOMER
     return create_response(data)
 
 

--- a/authorizenet/views.py
+++ b/authorizenet/views.py
@@ -51,6 +51,7 @@ class AIMPayment(object):
                  payment_form_class=AIMPaymentForm,
                  context={},
                  billing_form_class=BillingAddressForm,
+                 shipping_form_class=None,
                  payment_template="authorizenet/aim_payment.html",
                  success_template='authorizenet/aim_success.html',
                  initial_data={}):
@@ -61,6 +62,7 @@ class AIMPayment(object):
         self.context = context
         self.initial_data = initial_data
         self.billing_form_class = billing_form_class
+        self.shipping_form_class = shipping_form_class
 
     def __call__(self, request):
         self.request = request
@@ -74,6 +76,9 @@ class AIMPayment(object):
                 initial=self.initial_data)
         self.context['billing_form'] = self.billing_form_class(
                 initial=self.initial_data)
+        if self.shipping_form_class:
+            self.context['shipping_form'] = self.shipping_form_class(
+                    initial=self.initial_data)
         return direct_to_template(self.request,
                                   self.payment_template,
                                   self.context)
@@ -81,8 +86,19 @@ class AIMPayment(object):
     def validate_payment_form(self):
         payment_form = self.payment_form_class(self.request.POST)
         billing_form = self.billing_form_class(self.request.POST)
-        if payment_form.is_valid() and billing_form.is_valid():
-            form_data = combine_form_data(payment_form, billing_form)
+        
+        if self.shipping_form_class:
+            shipping_form = self.shipping_form_class(self.request.POST)
+
+        #if shipping for exists also validate it
+        if payment_form.is_valid() and billing_form.is_valid() and (not self.shipping_form_class or (shipping_form.is_valid() and shipping_form)):
+            
+            if not self.shipping_form_class:
+                args = payment_form, billing_form
+            else:
+                args = payment_form, billing_form, shipping_form
+            
+            form_data = combine_form_data(*args)
             response = process_payment(form_data, self.extra_data)
             self.context['response'] = response
             if response.is_approved:
@@ -93,6 +109,8 @@ class AIMPayment(object):
                 self.context['errors'] = self.processing_error
         self.context['payment_form'] = payment_form
         self.context['billing_form'] = billing_form
+        if self.shipping_form_class:
+            self.context['shipping_form'] = shipping_form
         self.context.setdefault('errors', self.form_error)
         return direct_to_template(self.request,
                                   self.payment_template,

--- a/authorizenet/views.py
+++ b/authorizenet/views.py
@@ -91,7 +91,7 @@ class AIMPayment(object):
             shipping_form = self.shipping_form_class(self.request.POST)
 
         #if shipping for exists also validate it
-        if payment_form.is_valid() and billing_form.is_valid() and (not self.shipping_form_class or (shipping_form.is_valid() and shipping_form)):
+        if payment_form.is_valid() and billing_form.is_valid() and (not self.shipping_form_class or shipping_form.is_valid()):
             
             if not self.shipping_form_class:
                 args = payment_form, billing_form


### PR DESCRIPTION
Added ShippingAddressForm with correct authorize.net fields and added it to optionally be used in the AIMPayment view. Changed the CVV2 field to be an IntegerField with max_value of 9999 to validate length. Added a check for the variable AUTHNET_EMAIL_CUSTOMER, which specifies whether or not authorize sends the customer an email. In my case, I was sending out a custom order email, so this was useful. If the variable doesn't exist it will send the email like normal.
