### PR TITLE
Moves the card_code parameter in a CIM Transaction to after order_info

### DIFF
--- a/authorizenet/cim.py
+++ b/authorizenet/cim.py
@@ -692,6 +692,9 @@ class CreateTransactionRequest(BaseRequest):
         self.add_extra_options()
         if order_info:
             self.add_order_info(**order_info)
+        if self.card_code:
+            card_code_node = self.get_text_node("cardCode", self.card_code)
+            self.type_node.appendChild(card_code_node)
 
     def add_transaction_node(self):
         transaction_node = self.document.createElement("transaction")
@@ -706,9 +709,6 @@ class CreateTransactionRequest(BaseRequest):
         if self.transaction_id:
             trans_id_node = self.get_text_node("transId", self.transaction_id)
             type_node.appendChild(trans_id_node)
-        if self.card_code:
-            card_code_node = self.get_text_node("cardCode", self.card_code)
-            type_node.appendChild(card_code_node)
         self.root.appendChild(transaction_node)
         self.type_node = type_node
 


### PR DESCRIPTION
Moved card_code insertion after order_info because Authorize.net throws errors when XML parameters are not in their designated order.

Previously, an error would only be thrown if both card_code and order_info were passed to cim.CreateTransactionRequest(), and I only tested it with card_code passed.
