### PR TITLE
Fix relatives version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,4 +25,5 @@ setup(name='django-authorizenet',
       ).read().strip(),
       test_suite='runtests.runtests',
       tests_require=['httmock'],
-      install_requires=['requests', 'django>=1.4', 'django-relatives>=0.2.0'])
+      install_requires=['requests', 'django>=1.4.2',
+                        'django-relatives>=0.3.1'])

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from setuptools import setup, find_packages
+from setuptools import setup
 import os
 
 setup(name='django-authorizenet',


### PR DESCRIPTION
django-relatives dropped support for Django 1.4 and then reintroduced it (with Django 1.4.2 being the minimum supported version).
