### PR TITLE
updated to use Akamai transaction urls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ dist/
 .tox
 htmlcov
 docs/_build/
+.idea/

--- a/authorizenet/__init__.py
+++ b/authorizenet/__init__.py
@@ -1,5 +1,0 @@
-AUTHNET_POST_URL = "https://secure2.authorize.net/gateway/transact.dll"
-AUTHNET_TEST_POST_URL = "https://test.authorize.net/gateway/transact.dll"
-AUTHNET_TEST_CIM_URL = "https://apitest.authorize.net/xml/v1/request.api"
-AUTHNET_CIM_URL = "https://api2.authorize.net/xml/v1/request.api"
-

--- a/authorizenet/__init__.py
+++ b/authorizenet/__init__.py
@@ -1,4 +1,5 @@
-AUTHNET_POST_URL = "https://secure.authorize.net/gateway/transact.dll"
+AUTHNET_POST_URL = "https://secure2.authorize.net/gateway/transact.dll"
 AUTHNET_TEST_POST_URL = "https://test.authorize.net/gateway/transact.dll"
 AUTHNET_TEST_CIM_URL = "https://apitest.authorize.net/xml/v1/request.api"
-AUTHNET_CIM_URL = "https://api.authorize.net/xml/v1/request.api"
+AUTHNET_CIM_URL = "https://api2.authorize.net/xml/v1/request.api"
+

--- a/authorizenet/admin.py
+++ b/authorizenet/admin.py
@@ -1,9 +1,8 @@
 from django.contrib import admin
 from django.core.urlresolvers import reverse
 from django.utils.safestring import mark_safe
-from authorizenet.models import (Response, CIMResponse, CustomerProfile,
-                                 CustomerPaymentProfile)
-from authorizenet.forms import CustomerPaymentForm, CustomerPaymentAdminForm
+from .models import Response, CIMResponse, CustomerProfile, CustomerPaymentProfile
+from .forms import CustomerPaymentForm, CustomerPaymentAdminForm
 from relatives.utils import object_edit_link
 
 

--- a/authorizenet/cim.py
+++ b/authorizenet/cim.py
@@ -2,12 +2,11 @@ import re
 import xml.dom.minidom
 
 from django.utils.datastructures import SortedDict
-from authorizenet.conf import settings
+from .conf import settings
 import requests
 
-from authorizenet import AUTHNET_CIM_URL, AUTHNET_TEST_CIM_URL
-from authorizenet.signals import customer_was_created, customer_was_flagged, \
-        payment_was_successful, payment_was_flagged
+from .settings import AUTHNET_CIM_URL, AUTHNET_TEST_CIM_URL
+from .signals import customer_was_created, customer_was_flagged, payment_was_successful, payment_was_flagged
 
 
 BILLING_FIELDS = ('firstName',
@@ -330,7 +329,7 @@ class BaseRequest(object):
         return node
 
     def create_response_object(self):
-        from authorizenet.models import CIMResponse
+        from .models import CIMResponse
         return CIMResponse.objects.create(result=self.result,
                                           result_code=self.resultCode,
                                           result_text=self.resultText)
@@ -769,7 +768,7 @@ class CreateTransactionRequest(BaseRequest):
         self.root.appendChild(extra_options_node)
 
     def create_response_object(self):
-        from authorizenet.models import CIMResponse, Response
+        from .models import CIMResponse, Response
         try:
             response = Response.objects.create_from_list(
                     self.transaction_result)

--- a/authorizenet/fields.py
+++ b/authorizenet/fields.py
@@ -6,8 +6,8 @@ from calendar import monthrange
 from django import forms
 from django.utils.translation import ugettext as _
 
-from authorizenet.conf import settings
-from authorizenet.creditcard import verify_credit_card
+from .conf import settings
+from .creditcard import verify_credit_card
 
 
 class CreditCardField(forms.CharField):

--- a/authorizenet/forms.py
+++ b/authorizenet/forms.py
@@ -1,8 +1,7 @@
 from django import forms
-from authorizenet.conf import settings
-from authorizenet.fields import CreditCardField, CreditCardExpiryField, \
-        CreditCardCVV2Field, CountryField
-from authorizenet.models import CustomerPaymentProfile
+from .conf import settings
+from .fields import CreditCardField, CreditCardExpiryField, CreditCardCVV2Field, CountryField
+from .models import CustomerPaymentProfile
 
 
 class SIMPaymentForm(forms.Form):

--- a/authorizenet/helpers.py
+++ b/authorizenet/helpers.py
@@ -2,8 +2,8 @@ import re
 
 import requests
 
-from authorizenet.conf import settings
-from authorizenet import AUTHNET_POST_URL, AUTHNET_TEST_POST_URL
+from .conf import settings
+from .settings import AUTHNET_POST_URL, AUTHNET_TEST_POST_URL
 
 
 class AIMPaymentHelper(object):

--- a/authorizenet/settings.py
+++ b/authorizenet/settings.py
@@ -1,4 +1,21 @@
-AUTHNET_POST_URL = "https://secure2.authorize.net/gateway/transact.dll"
-AUTHNET_TEST_POST_URL = "https://test.authorize.net/gateway/transact.dll"
-AUTHNET_TEST_CIM_URL = "https://apitest.authorize.net/xml/v1/request.api"
-AUTHNET_CIM_URL = "https://api2.authorize.net/xml/v1/request.api"
+from django.conf import settings
+
+try:
+    AUTHNET_POST_URL = settings.AUTHNET_POST_URL
+except AttributeError:
+    AUTHNET_POST_URL = "https://secure2.authorize.net/gateway/transact.dll"
+
+try:
+    AUTHNET_TEST_POST_URL = settings.AUTHNET_TEST_POST_URL
+except AttributeError:
+    AUTHNET_TEST_POST_URL = "https://test.authorize.net/gateway/transact.dll"
+
+try:
+    AUTHNET_TEST_CIM_URL = settings.AUTHNET_TEST_CIM_URL
+except AttributeError:
+    AUTHNET_TEST_CIM_URL = "https://apitest.authorize.net/xml/v1/request.api"
+
+try:
+    AUTHNET_CIM_URL = settings.AUTHNET_CIM_URL
+except AttributeError:
+    AUTHNET_CIM_URL = "https://api2.authorize.net/xml/v1/request.api"

--- a/authorizenet/settings.py
+++ b/authorizenet/settings.py
@@ -1,0 +1,4 @@
+AUTHNET_POST_URL = "https://secure2.authorize.net/gateway/transact.dll"
+AUTHNET_TEST_POST_URL = "https://test.authorize.net/gateway/transact.dll"
+AUTHNET_TEST_CIM_URL = "https://apitest.authorize.net/xml/v1/request.api"
+AUTHNET_CIM_URL = "https://api2.authorize.net/xml/v1/request.api"

--- a/authorizenet/utils.py
+++ b/authorizenet/utils.py
@@ -2,10 +2,10 @@ import hmac
 
 from django.core.exceptions import ImproperlyConfigured
 
-from authorizenet.conf import settings
-from authorizenet.helpers import AIMPaymentHelper
-from authorizenet.models import Response
-from authorizenet.signals import payment_was_successful, payment_was_flagged
+from .conf import settings
+from .helpers import AIMPaymentHelper
+from .models import Response
+from .signals import payment_was_successful, payment_was_flagged
 
 
 def get_fingerprint(x_fp_sequence, x_fp_timestamp, x_amount):

--- a/authorizenet/views.py
+++ b/authorizenet/views.py
@@ -3,16 +3,15 @@ try:
 except ImportError:
     import md5 as hashlib
 
-from authorizenet.conf import settings
+from .conf import settings
 from django.shortcuts import render
 from django.views.decorators.csrf import csrf_exempt
 from django.views.generic.edit import CreateView, UpdateView
 
-from authorizenet.forms import AIMPaymentForm, BillingAddressForm, CustomerPaymentForm
-from authorizenet.models import CustomerProfile, CustomerPaymentProfile
-from authorizenet.models import Response
-from authorizenet.signals import payment_was_successful, payment_was_flagged
-from authorizenet.utils import process_payment, combine_form_data
+from .forms import AIMPaymentForm, BillingAddressForm, CustomerPaymentForm
+from .models import Response
+from .signals import payment_was_successful, payment_was_flagged
+from .utils import process_payment, combine_form_data
 
 
 @csrf_exempt

--- a/sample_project/samplestore/views.py
+++ b/sample_project/samplestore/views.py
@@ -9,7 +9,7 @@ from django.template import RequestContext
 from django.contrib.sites.models import Site
 from django.contrib.auth.decorators import login_required
 
-from authorizenet import AUTHNET_POST_URL, AUTHNET_TEST_POST_URL
+from authorizenet.settings import AUTHNET_POST_URL, AUTHNET_TEST_POST_URL
 from authorizenet.forms import SIMPaymentForm, SIMBillingForm, ShippingAddressForm
 from authorizenet.models import Response
 from authorizenet.views import AIMPayment


### PR DESCRIPTION
[Authorize.net is upgrading their system to use Akamai routing, which means new transaction urls.](https://community.developer.authorize.net/t5/The-Authorize-Net-Developer-Blog/Important-Authorize-Net-Networking-Change/ba-p/51272?utm_campaign=Akamai%20CS%20Reminder&utm_medium=email&utm_source=Eloqua&elqTrackId=8c90d24001e048249d947fef5dd8e680&elq=89a71af7a3064b47947a1a333822138b&elqaid=495&elqat=1&elqCampaignId=259)
